### PR TITLE
Convert 2 mulled-cli doctests to unit-test style test

### DIFF
--- a/lib/galaxy/tools/deps/mulled/mulled_update_singularity_containers.py
+++ b/lib/galaxy/tools/deps/mulled/mulled_update_singularity_containers.py
@@ -24,16 +24,7 @@ def get_list_from_file(filename):
 
 def docker_to_singularity(container, installation, filepath, no_sudo=False):
     """
-    Convert docker to singularity container
-    >>> from glob import glob
-    >>> import os, shutil
-    >>> os.mkdir('/tmp/singtest')
-    >>> glob('/tmp/singtest/abundancebin:1.0.1--0')
-    []
-    >>> docker_to_singularity('abundancebin:1.0.1--0', 'singularity', '/tmp/singtest', no_sudo=True)
-    >>> glob('/tmp/singtest/abundancebin:1.0.1--0')
-    ['/tmp/singtest/abundancebin:1.0.1--0']
-    >>> shutil.rmtree('/tmp/singtest')
+    Convert docker to singularity container.
     """
 
     try:

--- a/test/unit/tools/mulled/test_get_tests.py
+++ b/test/unit/tools/mulled/test_get_tests.py
@@ -1,0 +1,25 @@
+from galaxy.tools.deps.mulled.get_tests import get_commands_from_yaml
+from galaxy.util import smart_str
+
+
+TEST_RECIPE = r"""
+{% set name = "eagle" %}
+package:
+  name: '{{ name }}'
+requirements:
+  run:
+    - python
+    - flask
+test:
+  imports:
+    - eagle
+  commands:
+    - eagle --help
+"""
+
+
+def test_get_commands_from_yaml():
+    commands = get_commands_from_yaml(smart_str(TEST_RECIPE))
+    assert commands['imports'] == ['eagle']
+    assert commands['commands'] == ['eagle --help']
+    assert commands['import_lang'] == 'python -c'

--- a/test/unit/tools/mulled/test_mulled_update_singularity_containers.py
+++ b/test/unit/tools/mulled/test_mulled_update_singularity_containers.py
@@ -1,0 +1,12 @@
+import pytest
+
+from galaxy.tools.deps.mulled.mulled_update_singularity_containers import docker_to_singularity
+from galaxy.util import which
+
+
+@pytest.mark.skipif(not which('singularity'), reason="requires singularity but singularity not on PATH")
+def test_docker_to_singularity(tmp_path):
+    tmp_dir = str(tmp_path)
+    errors = docker_to_singularity('abundancebin:1.0.1--0', 'singularity', tmp_dir, no_sudo=True)
+    assert errors is None
+    assert tmp_path.joinpath('abundancebin:1.0.1--0').exists()


### PR DESCRIPTION
We may or may not want add these as integration or unit tests.
It probably makes a lot of sense to keep these as unit tests
and skip when singularity is not available.

I hope this gives you an idea on how to convert the remaining tests.